### PR TITLE
feat: alwaysHideCloseButton prop

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -18,6 +18,7 @@ export default class BetaBar extends React.Component {
       save: React.PropTypes.func,
     }),
     onFallback: React.PropTypes.func,
+    alwaysHideCloseButton: React.PropTypes.bool,
     stillRenderWhenClosed: React.PropTypes.bool,
   }
   static defaultProps = {
@@ -95,7 +96,8 @@ export default class BetaBar extends React.Component {
       <a {...fallbackButtonProps}></a>
     );
 
-    const displayCloseButton = !(this.state && this.state.wasDismissed);
+    const displayCloseButton = !(this.state && this.state.wasDismissed) &&
+      (this.props.alwaysHideCloseButton !== true);
 
     return (
       <BarWrapper className={classNames.join(' ')} classNamePrefix="beta-bar" onClose={this.handleDismiss} close={displayCloseButton} stillRenderWhenClosed={this.props.stillRenderWhenClosed}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-beta-bar",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Beta bar",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
This adds a prop that makes the close button never show up, regardless of cookie logic.

It also marks the last time we add a prop to this component before we push a major and drop all the crap in it lel.