### PR TITLE
fix: Correct propTypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,8 @@ export default class BetaBar extends React.Component {
       onFallback: React.PropTypes.func,
       alwaysHideCloseButton: React.PropTypes.bool,
       stillRenderWhenClosed: React.PropTypes.bool,
-      renderFeedbackLink: React.PropTypes.bool,
-      renderFallbackLink: React.PropTypes.bool,
+      renderFeedbackLink: React.PropTypes.func,
+      renderFallbackLink: React.PropTypes.func,
     };
   }
   static get defaultProps() {


### PR DESCRIPTION
Changed PropTypes.bool to PropTypes.func in a place where a function should be used.

This was causing annoying warnings.